### PR TITLE
Preserve selected text when applying snippet

### DIFF
--- a/snippets.json
+++ b/snippets.json
@@ -1,7 +1,7 @@
 {
     "Addition": {
         "prefix": "Addition",
-        "body": "{++$1++}",
+        "body": "{++$TM_SELECTED_TEXT++}",
         "description": "Add text."
     },
     "Deletion": {
@@ -16,7 +16,7 @@
     },
     "Comment": {
         "prefix": "Comment",
-        "body": "{>>$1<<}",
+        "body": "{>>$TM_SELECTED_TEXT<<}",
         "description": "Add comment."
     },
     "Highlight": {


### PR DESCRIPTION
The comment and addition snippets did not preserve selected text. This small change to `snippets.json` seems to fix this.